### PR TITLE
Removed aulavirtual-blackbox-monitoring probe from Instituto nacional.

### DIFF
--- a/monitoring/additional-probes.yaml
+++ b/monitoring/additional-probes.yaml
@@ -13,27 +13,9 @@ spec:
       static:
       - https://preview.cajalosandes.virtual-labx.cl/heartbeat
       - https://studio.cajalosandes.virtual-labx.cl/heartbeat
-      # - https://cajalosandes.virtual-labx.cl/heartbeat
       - https://jcpp2030.cl/heartbeat
       - https://studio.jcpp2030.cl/heartbeat
       - https://preview.jcpp2030.cl/heartbeat
-# ---
-# kind: Probe
-# apiVersion: monitoring.coreos.com/v1
-# metadata:
-#  name: norteamericano-blackbox-monitoring
-#  namespace: monitoring
-# spec:
-#  interval: 90s
-#  module: http_2xx
-#  prober:
-#    url: blackbox-exporter.monitoring.svc.cluster.local:19115
-#  targets:
-#    staticConfig:
-#      static:
-#      - https://norteamericano.virtual-labx.cl/heartbeat
-#      - https://studio.norteamericano.virtual-labx.cl/heartbeat
-#      - https://preview.norteamericano.virtual-labx.cl/heartbeat
 ---
 kind: Probe
 apiVersion: monitoring.coreos.com/v1
@@ -51,18 +33,18 @@ spec:
      - https://open.uchile.cl/heartbeat
      - https://studio.open.uchile.cl/heartbeat
      - https://preview.open.uchile.cl/heartbeat
----
-kind: Probe
-apiVersion: monitoring.coreos.com/v1
-metadata:
-  name: aulavirtual-blackbox-monitoring
-  namespace: monitoring
-spec:
-  interval: 60s
-  module: http_2xx
-  prober:
-    url: blackbox-exporter.monitoring.svc.cluster.local:19115
-  targets:
-    staticConfig:
-      static:
-      - https://aulavirtual.institutonacional.cl/
+
+# kind: Probe
+# apiVersion: monitoring.coreos.com/v1
+# metadata:
+#   name: aulavirtual-blackbox-monitoring
+#   namespace: monitoring
+# spec:
+#   interval: 60s
+#   module: http_2xx
+#   prober:
+#     url: blackbox-exporter.monitoring.svc.cluster.local:19115
+#   targets:
+#     staticConfig:
+#       static:
+#       - https://aulavirtual.institutonacional.cl/


### PR DESCRIPTION
**- Removed aulavirtual-blackbox-monitoring probe from Instituto nacional.**
**- Removed probes for ex-platforms Norteamericano and Caja Los Andes from additional-probes.yml.**