### PR TITLE
chore: reestructures job assignment and dedicated times

### DIFF
--- a/edx-backup/eol.yaml
+++ b/edx-backup/eol.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: eol-backup-00
 spec:
-  schedule: "0 11,14,17,20 * * *"
+  schedule: "0 15,19 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 2

--- a/edx-backup/uabierta.yaml
+++ b/edx-backup/uabierta.yaml
@@ -3,8 +3,7 @@ kind: CronJob
 metadata:
   name: uabierta-backup-00
 spec:
-  suspend: true
-  schedule: "0 17 * * *"
+  schedule: "0 13,16,19 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 2
@@ -59,6 +58,7 @@ kind: CronJob
 metadata:
   name: uabierta-backup-30
 spec:
+  suspend: true
   schedule: "30 12,15,18 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 2
@@ -114,7 +114,7 @@ kind: CronJob
 metadata:
   name: uabierta-backup-daily
 spec:
-  schedule: "30 7 * * *"
+  schedule: "0 9 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 2


### PR DESCRIPTION
El cambio es:
- Atrasar uabierta-daily 1h30m para evitar sobrelape con eol-daily y vlabx-daily.
- Reducir la frecuencia y ventana de trabajo de eol-00 para considerar su mayor demora y dejando más espacio para uabierta-daily.
- Cambiar uabierta-30 por uabierta-00 para que hagan lo mismo pero 30m más tarde y así evitar sobrelape con nuevo horario uabierta-daily.