### PR TITLE
chore(argocd): disable automatic deployments for edx-staging

### DIFF
--- a/projects/edx-staging/project.yaml
+++ b/projects/edx-staging/project.yaml
@@ -52,9 +52,6 @@ spec:
     targetRevision: HEAD
   project: edx-staging
   syncPolicy:
-    automated:
-      prune: false
-      selfHeal: false
     syncOptions:
     - CreateNamespace=true
   ignoreDifferences:


### PR DESCRIPTION
- Removed automatic sync configuration in the edx-staging project in Argo CD.
- Deployments will now require manual sync.