### PR TITLE
chore(openuchile/nginx): disable argocd autosync

### DIFF
--- a/projects/openuchile/nginx.yaml
+++ b/projects/openuchile/nginx.yaml
@@ -13,8 +13,5 @@ spec:
     targetRevision: HEAD
   project: openuchile-services
   syncPolicy:
-    automated:
-      prune: false
-      selfHeal: false
     syncOptions:
     - CreateNamespace=true


### PR DESCRIPTION
Disable ArgoCD autosync for ingress-nginx in openuchile cluster to ease controller upgrade.