### PR TITLE
chore(graylog): remove monitoring from old ArgoCD

### DIFF
--- a/.github/workflows/kustomize.yml
+++ b/.github/workflows/kustomize.yml
@@ -22,10 +22,6 @@ jobs:
         run: |
           kustomize build edx-backup > /dev/null
 
-      - name: Check graylog build
-        run: |
-          kustomize build graylog > /dev/null
-
       - name: Check reloader build
         run: |
           kustomize build reloader > /dev/null

--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - edx-staging/project.yaml
 - edx-ou-staging/project.yaml
 - reloader/project.yaml
-- graylog/project.yaml
+# - graylog/project.yaml
 - edx-sandbox/project.yaml
 - edx-backup/project.yaml
 - service-backup/project.yaml


### PR DESCRIPTION
Removed `graylog` project.