### PR TITLE
chore(service-backup): remove monitoring from old ArgoCD

### DIFF
--- a/.github/workflows/kustomize.yml
+++ b/.github/workflows/kustomize.yml
@@ -26,10 +26,6 @@ jobs:
         run: |
           kustomize build reloader > /dev/null
 
-      - name: Check service-backup build
-        run: |
-          kustomize build service-backup > /dev/null
-
       - name: Check projects build
         run: |
           kustomize build projects > /dev/null

--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 # - graylog/project.yaml
 - edx-sandbox/project.yaml
 - edx-backup/project.yaml
-- service-backup/project.yaml
+# - service-backup/project.yaml
 # - metabase/project.yaml
 # - otrs/project.yaml
 # - portal-eol/project.yaml


### PR DESCRIPTION
Removed `service-backup` project.