### PR TITLE
chore: remove moodle-virtuallabx & backup from old ArgoCD

### DIFF
--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 - norteamericano/edx-norteamericano.yaml
 - edx-virtuallabx/virtuallabx.yaml
 # - docs-eol/project.yaml
-- ./moodle-virtuallabx/moodle-backup.yaml
+# - ./moodle-virtuallabx/moodle-backup.yaml
 # - ./moodle-virtuallabx/moodle-virtuallabx.yaml
 # - test-host-eol/project.yaml
 # - emi-project/project.yaml

--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 - edx-virtuallabx/virtuallabx.yaml
 # - docs-eol/project.yaml
 - ./moodle-virtuallabx/moodle-backup.yaml
-- ./moodle-virtuallabx/moodle-virtuallabx.yaml
+# - ./moodle-virtuallabx/moodle-virtuallabx.yaml
 # - test-host-eol/project.yaml
 # - emi-project/project.yaml
 


### PR DESCRIPTION
Removed `moodle-virtuallabx` & `moodle-backup` project.