### PR TITLE
ci: adapt repository dispatch workflows to the main branch

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: 'main'
 
       - name: Install kustomize
         uses: imranismail/setup-kustomize@v2.1.0
@@ -35,7 +37,7 @@ jobs:
             git config --global user.email "${{ github.actor }}@users.noreply.github.com"
             git add docs-eol/kustomization.yaml
             git commit -m "Update docs-eol version"
-            git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/eol-uchile/argocd-config.git HEAD:master
+            git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/eol-uchile/argocd-config.git HEAD:main
           else
             echo "No changes to commit. Skipping commit step."
           fi

--- a/.github/workflows/update-portal.yml
+++ b/.github/workflows/update-portal.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: 'main'
 
       - name: Install kustomize
         uses: imranismail/setup-kustomize@v2.1.0
@@ -35,7 +37,7 @@ jobs:
             git config --global user.email "${{ github.actor }}@users.noreply.github.com"
             git add portal-eol/kustomization.yaml
             git commit -m "Update portal-eol version"
-            git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/eol-uchile/argocd-config.git HEAD:master
+            git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/eol-uchile/argocd-config.git HEAD:main
           else
             echo "No changes to commit. Skipping commit step."
           fi


### PR DESCRIPTION
Update the branch references in the checkout and push steps in the update-docs and update-portal workflows so that they are ready when the main branch becomes the default.