### PR TITLE
chore: remove edx-virtuallabx & edx-norteamericano from old ArgoCD

### DIFF
--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -22,7 +22,7 @@ resources:
 - openuchile/sealed-secrets.yaml
 - openuchile/edx-openuchile.yaml
 - openuchile/metrics.yaml
-- norteamericano/edx-norteamericano.yaml
+# - norteamericano/edx-norteamericano.yaml
 # - edx-virtuallabx/virtuallabx.yaml
 # - docs-eol/project.yaml
 # - ./moodle-virtuallabx/moodle-backup.yaml

--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -23,7 +23,7 @@ resources:
 - openuchile/edx-openuchile.yaml
 - openuchile/metrics.yaml
 - norteamericano/edx-norteamericano.yaml
-- edx-virtuallabx/virtuallabx.yaml
+# - edx-virtuallabx/virtuallabx.yaml
 # - docs-eol/project.yaml
 # - ./moodle-virtuallabx/moodle-backup.yaml
 # - ./moodle-virtuallabx/moodle-virtuallabx.yaml


### PR DESCRIPTION
Remove `edx-norteamericano` y `edx-virtuallabx` project from old ArgoCD.