### PR TITLE
chore(edx-eol): project removed from kustomization

### DIFF
--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 # - metabase/project.yaml
 # - otrs/project.yaml
 # - portal-eol/project.yaml
-- edx-eol/project.yaml
+# - edx-eol/project.yaml
 - edx-uabierta/project.yaml
 - edx-dgd/project.yaml
 - eol-permissions.yaml


### PR DESCRIPTION
Remove `edx-eol` project from old ArgoCD