### PR TITLE
chore(edx-uabierta): project removed from kustomization

### DIFF
--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # - otrs/project.yaml
 # - portal-eol/project.yaml
 # - edx-eol/project.yaml
-- edx-uabierta/project.yaml
+# - edx-uabierta/project.yaml
 - edx-dgd/project.yaml
 - eol-permissions.yaml
 - openuchile/project.yaml


### PR DESCRIPTION
Remove `edx-uabierta` project from old ArgoCD